### PR TITLE
feat: ability to load existing typegen schema programatically

### DIFF
--- a/oas-codegen-parser/examples/generators/class-validator.ts
+++ b/oas-codegen-parser/examples/generators/class-validator.ts
@@ -55,7 +55,7 @@ const findModelFields = (model: TypeGenModel<any>, search: string) => {
   }
 
   return found;
-}
+};
 
 const schemaGen = (model: TypeGenModel<any>, genModel: ModelGen): { content: string; imports: Imports } => {
   const schema = [];
@@ -76,7 +76,7 @@ const schemaGen = (model: TypeGenModel<any>, genModel: ModelGen): { content: str
     if (dep.tType === TypeGenTypes.schema) {
       const depModel = genModel(dep, imports);
       if (depModel === 'json') {
-        findModelFields(model, dep.name)?.forEach(field => field.subtype = 'json');
+        findModelFields(model, dep.name)?.forEach((field) => (field.subtype = 'json'));
       } else if (depModel) {
         schema.push(depModel);
       }
@@ -411,7 +411,7 @@ const augmentMethodParam = (model: TypeGenModel<OpenAPIV3.ParameterObject>): Typ
   await mkdir(outDir, { recursive: true }).catch(() => null);
   await mkdir(dirname(indexFilePath), { recursive: true }).catch(() => null);
 
-  await typegen.parseSchema(schema);
+  await typegen.loadParsed(schema);
 
   const indexExportKeys = [...indexExports.keys()].sort();
 

--- a/oas-codegen-parser/package-lock.json
+++ b/oas-codegen-parser/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@acrontum/oas-codegen-parser",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@acrontum/oas-codegen-parser",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "ISC",
       "bin": {
         "oas-codegen-parser": "dist/typegen.js",

--- a/oas-codegen-parser/package.json
+++ b/oas-codegen-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acrontum/oas-codegen-parser",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "OpenAPI schema parser / mapper for codegen tools",
   "repository": {
     "type": "git",

--- a/oas-codegen-parser/tsconfig.json
+++ b/oas-codegen-parser/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@tsconfig/node18/tsconfig.json",
   "compilerOptions": {
+    "moduleResolution": "nodenext",
     "rootDir": "./",
     "baseUrl": "./",
     "sourceMap": false,


### PR DESCRIPTION
- for multiple generators, instead of parsing the api spec each time, add cli flag to allow loading pre-parsed typgen output and emit model events.
- fix naming conflict - just use potentially ugly opid name
- update example class-validator