### PR TITLE
feat/nestgen-qol

### DIFF
--- a/oas-nestgen/package-lock.json
+++ b/oas-nestgen/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.3",
       "license": "ISC",
       "dependencies": {
-        "@acrontum/oas-codegen-parser": "^1.0.0",
+        "@acrontum/oas-codegen-parser": "^1.2.0",
         "ts-morph": "^20.0.0"
       },
       "bin": {
@@ -26,9 +26,10 @@
       }
     },
     "node_modules/@acrontum/oas-codegen-parser": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@acrontum/oas-codegen-parser/-/oas-codegen-parser-1.0.0.tgz",
-      "integrity": "sha512-Sd6B5sjNCKvgZesn73JvtI9eVqRsijxo78sDlcql9/3bvetEteQKOh1q8Kow9VEBasE/LNIyx21SBWp0D+/wyg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@acrontum/oas-codegen-parser/-/oas-codegen-parser-1.2.0.tgz",
+      "integrity": "sha512-Hpeia3u4kSHuHmcbPFa3J3B9+L36ZNjUzTU2WCgEqp/wnQyvILrTR+YhccD5Ky4XaWu0Dq0EFES5vGpt3qhUMw==",
+      "license": "ISC",
       "bin": {
         "oas-codegen-parser": "dist/typegen.js",
         "ocp": "dist/typegen.js"

--- a/oas-nestgen/package.json
+++ b/oas-nestgen/package.json
@@ -35,11 +35,12 @@
     "typescript": "^5.2.2"
   },
   "dependencies": {
-    "@acrontum/oas-codegen-parser": "^1.0.0",
+    "@acrontum/oas-codegen-parser": "^1.2.0",
     "ts-morph": "^20.0.0"
   },
   "files": [
-    "dist/",
+    "dist/**/*.ts",
+    "dist/**/*.d.ts",
     "readme.md"
   ]
 }

--- a/oas-nestgen/src/config.ts
+++ b/oas-nestgen/src/config.ts
@@ -4,6 +4,7 @@ import {
   extraDecorators,
   getBodyParams,
   getControllerDecorators,
+  getDefaultServiceContent,
   getMethodControllerName,
   getMethodName,
   getReturnValue,
@@ -19,6 +20,7 @@ export type Config = {
   typegenPath: string;
   stubService: boolean;
   dryRun: boolean;
+  verbose: boolean;
 
   appModulePath: string;
   modulesPath: string;
@@ -28,6 +30,9 @@ export type Config = {
   typesImport: string;
 
   ignoredOpIds: string[] | null;
+
+  maxLineLength: number;
+  indent: string;
 
   getMethodName: typeof getMethodName;
   getReturnValue: typeof getReturnValue;
@@ -40,6 +45,7 @@ export type Config = {
   getSubPath: typeof getSubPath;
   getBodyParams: typeof getBodyParams;
   getControllerDecorators: typeof getControllerDecorators;
+  getDefaultServiceContent: typeof getDefaultServiceContent;
 };
 
 export const config: Config = {
@@ -47,6 +53,7 @@ export const config: Config = {
   typegenPath: 'typegen.json',
   stubService: true,
   dryRun: false,
+  verbose: false,
 
   appModulePath: './src/app.module.ts',
   modulesPath: './src/modules/',
@@ -56,6 +63,9 @@ export const config: Config = {
   typesImport: 'src/types',
 
   ignoredOpIds: null,
+
+  maxLineLength: 210,
+  indent: '  ',
 
   getMethodName,
   getReturnValue,
@@ -68,6 +78,7 @@ export const config: Config = {
   getSubPath,
   getBodyParams,
   getControllerDecorators,
+  getDefaultServiceContent,
 };
 
 export const getConfig = async (overrides: Partial<Config> = {}) => {

--- a/oas-nestgen/src/console-patch.ts
+++ b/oas-nestgen/src/console-patch.ts
@@ -1,0 +1,5 @@
+// https://github.com/nodejs/node/issues/53661
+const oldError = console.error;
+const oldWarn = console.warn;
+console.error = (...args: unknown[]) => oldError('\x1b[0;0m', ...args);
+console.warn = (...args: unknown[]) => oldWarn('\x1b[0;0m', ...args);

--- a/oas-nestgen/src/parse-typegen.ts
+++ b/oas-nestgen/src/parse-typegen.ts
@@ -45,6 +45,7 @@ export type Method = {
   controllerName: string;
   url: string;
   opid: string;
+  typegenMethod: TypeGenMethod;
   imports?: Import[];
 };
 
@@ -105,6 +106,13 @@ export const nameHeadersParams = (typegenMethod: TypeGenMethod) =>
   typegenMethod.headerParams?.length ? `${typegenMethod.name}Headers` : null;
 
 export const isDefaultProduces = (contentType: string) => true;
+
+export const getDefaultServiceContent = (method: Method): { statements: string[]; imports: [string, string][] } => {
+  return {
+    statements: ['throw new NotImplementedException();'],
+    imports: [['@nestjs/common', 'NotImplementedException']],
+  };
+};
 
 const basicTypes = {
   string: true,
@@ -216,6 +224,7 @@ export const methodFromTypegen = (config: Config, typegenMethod: TypeGenMethod):
     controllerName,
     opid,
     url,
+    typegenMethod,
   };
   const extraMethodDecorators = config.extraDecorators(typegenMethod, parsedMethod);
   parsedMethod.decorators.push(...extraMethodDecorators?.decorators);

--- a/oas-nestgen/src/templates.ts
+++ b/oas-nestgen/src/templates.ts
@@ -1,3 +1,5 @@
+import { config } from './config';
+
 export const getController = (name: string) => `\
 export class ${name}Controller {}
 `;
@@ -21,10 +23,19 @@ import { Injectable } from '@nestjs/common';
 export class ${name}Service {}
 `;
 
+export const formatOpidType = (opIds: string[], indent = config.indent) => {
+  let opIdExport = `'${opIds.join("' | '")}'`;
+  if (opIdExport?.length > config.maxLineLength) {
+    opIdExport = `\n${indent}| '${opIds.join(`'\n${indent}| '`)}'`;
+  }
+
+  return opIdExport;
+};
+
 export const getOpIdDecorator = (opIds: string[]) => `\
 import { CustomDecorator, SetMetadata } from '@nestjs/common';
 
 export const OP_ID = 'OperationId';
-export type OperationId = '${opIds.join("' | '")}';
+export type OperationId = ${formatOpidType(opIds)};
 export const OpId = (id: OperationId): CustomDecorator => SetMetadata(OP_ID, id);
 `;

--- a/oas-nestgen/tsconfig.json
+++ b/oas-nestgen/tsconfig.json
@@ -49,10 +49,10 @@
     // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
 
     /* Emit */
-    // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+    "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
     // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
     // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
-    "sourceMap": false,                                /* Create source map files for emitted JavaScript files. */
+    "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
     // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
     "outDir": "dist",                                   /* Specify an output folder for all emitted files. */


### PR DESCRIPTION
- added import sorting, proper namespace import resolution
- added formatting options for imports and op id decorator
- on dry run, create files in virtual project and support outputting the changes to the terminal
- added support for configuring default service content
- patched console coloured output https://github.com/nodejs/node/issues/53661
- added dts and source map to dev build (stripped in dist files)
- bump codegen parser dep