### PR TITLE
fix/include-default

### DIFF
--- a/oas-codegen-parser/lib.ts
+++ b/oas-codegen-parser/lib.ts
@@ -112,7 +112,7 @@ export const omitFromExtras = {
   items: true,
   $ref: true,
   properties: true,
-  default: true,
+  // default: true,
   // required: true,
   enum: true,
   description: true,


### PR DESCRIPTION
probably this was omitted because it was parsed separately at some point, but not any more. Added back in