### PR TITLE
fix/publish-and-support-ts

### DIFF
--- a/oas-codegen-parser/package-lock.json
+++ b/oas-codegen-parser/package-lock.json
@@ -29,9 +29,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.0.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.0.tgz",
-      "integrity": "sha512-yZQa2zm87aRVcqDyH5+4Hv9KYgSdgwX1rFnGvpbzMaC7YAljmhBET93TPiTd3ObwTL+gSpIzPKg5BqVxdCvxKg==",
+      "version": "24.1.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.1.0.tgz",
+      "integrity": "sha512-ut5FthK5moxFKH2T1CUOC6ctR67rQRvvHdFLCD2Ql6KXmMuCrjsSsRI9UsLCm9M18BMwClv4pn327UvB7eeO1w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -63,13 +63,15 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/commander": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
       "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 10"
       }
@@ -79,6 +81,7 @@
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
       "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.5",
         "neo-async": "^2.6.2",
@@ -126,6 +129,7 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "dev": true,
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -134,13 +138,15 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -160,13 +166,15 @@
       "version": "12.1.3",
       "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
       "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/parse-github-url": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/parse-github-url/-/parse-github-url-1.0.3.tgz",
       "integrity": "sha512-tfalY5/4SqGaV/GIGzWyHnFjlpTPTNpENR9Ea2lLldSJ8EWXMsvacWucqY3m3I4YPtas15IxTLQVQ5NSYXPrww==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "parse-github-url": "cli.js"
       },
@@ -185,10 +193,11 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -201,6 +210,7 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -210,6 +220,7 @@
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -219,7 +230,8 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/typescript": {
       "version": "5.8.3",
@@ -236,10 +248,11 @@
       }
     },
     "node_modules/uglify-js": {
-      "version": "3.19.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.0.tgz",
-      "integrity": "sha512-wNKHUY2hYYkf6oSFfhwwiHo4WCHzHmzcXsqXYTN9ja3iApYIFbb2U6ics9hBcYLHcYGQoAlwnZlTrf3oF+BL/Q==",
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "optional": true,
       "bin": {
         "uglifyjs": "bin/uglifyjs"
@@ -259,13 +272,15 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "dev": true
+      "dev": true,
+      "license": "BSD-2-Clause"
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -275,7 +290,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/oas-nestgen/package.json
+++ b/oas-nestgen/package.json
@@ -12,6 +12,7 @@
     "oas-nestgen": "dist/cli.js"
   },
   "scripts": {
+    "prepublishOnly": "npm run build",
     "prebuild": "rm -rf dist",
     "build": "tsc",
     "lint": "prettier --write 'src/*'",

--- a/oas-nestgen/src/cli.ts
+++ b/oas-nestgen/src/cli.ts
@@ -2,7 +2,6 @@
 
 import { parseArgs, ParseArgsConfig } from 'node:util';
 import { config, Config, getConfig } from './config';
-import './console-patch';
 import { generate } from './oas-nestgen';
 import { camelCase } from './string-utils';
 

--- a/oas-nestgen/src/config.ts
+++ b/oas-nestgen/src/config.ts
@@ -83,15 +83,32 @@ export const config: Config = {
 
 export const getConfig = async (overrides: Partial<Config> = {}) => {
   config.configFile = overrides.configFile || config.configFile;
-  const supportedExtensions = ['', '.js', '.json'];
 
-  for (const ext of supportedExtensions) {
+  if (overrides.configFile) {
+    try {
+      if (await exists(join(process.cwd(), overrides.configFile))) {
+        Object.assign(config, require(join(process.cwd(), overrides.configFile)));
+
+        return Object.assign(config, overrides);
+      }
+    } catch (e) {
+      throw new Error(`Failed to load config ${overrides.configFile}: ${(e as Error).message}`);
+    }
+  }
+
+  const defaultExtensions = ['', '.js', '.json'];
+
+  for (const ext of defaultExtensions) {
     const configFile = `${config.configFile}${ext}`;
 
     if (await exists(join(process.cwd(), configFile))) {
-      Object.assign(config, require(join(process.cwd(), configFile)));
+      try {
+        Object.assign(config, require(join(process.cwd(), configFile)));
 
-      return Object.assign(config, overrides);
+        return Object.assign(config, overrides);
+      } catch (e) {
+        throw new Error(`Failed to load config ${overrides.configFile}: ${(e as Error).message}`);
+      }
     }
   }
 

--- a/oas-nestgen/src/console-patch.ts
+++ b/oas-nestgen/src/console-patch.ts
@@ -1,5 +1,0 @@
-// https://github.com/nodejs/node/issues/53661
-const oldError = console.error;
-const oldWarn = console.warn;
-console.error = (...args: unknown[]) => oldError('\x1b[0;0m', ...args);
-console.warn = (...args: unknown[]) => oldWarn('\x1b[0;0m', ...args);

--- a/oas-nestgen/src/oas-nestgen.ts
+++ b/oas-nestgen/src/oas-nestgen.ts
@@ -10,7 +10,6 @@ import {
   modifyService,
 } from './ast-parsing';
 import { Config } from './config';
-import './console-patch';
 import { assertFileFromTemplate, exists } from './file-utils';
 import { getTypesToGen, Method, Module } from './parse-typegen';
 import { getController, getModule, getOpIdDecorator, getService } from './templates';
@@ -193,3 +192,11 @@ export const generate = async (config: Config) => {
     console.log('- no files were harmed in the running of this command (dry-run) -');
   }
 };
+
+export * from './ast-parsing';
+export * from './cli';
+export * from './config';
+export * from './file-utils';
+export * from './parse-typegen';
+export * from './string-utils';
+export * from './templates';


### PR DESCRIPTION
- fix: prepublish script forces a build first
- added: --config-file when passed directly is loaded without validating extension. meaning node --experimental-strip-types oas-nestgen -c config.ts will load the ts file directly.
- enh: export everything from main file
- enh: cleanup old console fix