### PR TITLE
fix/codegen-parser-not-loading-references

### DIFF
--- a/oas-codegen-parser/typegen.ts
+++ b/oas-codegen-parser/typegen.ts
@@ -44,6 +44,7 @@ export class TypeGen {
 
   async loadParsed(typegen: typeof this.parsedSchemas, emit = true): Promise<void> {
     this.parsedSchemas = typegen;
+    this.refContentMap = this.parsedSchemas.referenceMap;
 
     if (!emit) {
       return;

--- a/oas-nestgen/package-lock.json
+++ b/oas-nestgen/package-lock.json
@@ -539,12 +539,12 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "10.2.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.3.tgz",
-      "integrity": "sha512-Rwi3pnapEqirPSbWbrZaa6N3nmqq4Xer/2XooiOKyV3q12ML06f7MOuc5DVH8ONZIFhwIYQ3yzPH4nt7iWHaTg==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -648,9 +648,9 @@
       }
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"


### PR DESCRIPTION
- when loading typegen programatically, forgot to load in the ref map - meaning resolveSchemaType would never work
- audit bump nestgen